### PR TITLE
Fix Incorrect parsing of SVG Content with Leading Newlines

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -166,6 +166,7 @@ export class ThemeBuilder {
 			const data = readFileSync(join(this.props.sources.outputThemes!, theme, fileName))
 				.toString()
 				.replace(/<!--.*?-->/g, '')
+				.trim()
 			const svgAst: any = parse(data)[0] as any
 
 			if (!this.sourceDict[key]) {


### PR DESCRIPTION
This PR addresses an issue where SVG content containing a newline at the beginning of the file is incorrectly parsed.

In such cases, the first element of the parsed content refers to the newline character instead of the SVG element. To resolve this issue, I've introduced a trim operation before parsing the SVG content. This ensures that any leading whitespace, including newlines, is removed, allowing for correct parsing of the SVG element as the first element in the parsed content.

<img width="339" alt="Screenshot 2024-04-04 at 22 41 30" src="https://github.com/steeze-ui/icons/assets/3771248/3d8f3cb9-145e-4ef3-97d0-173c9f1772e6">
