### PR TITLE
Resolve deprecated svelte package.json spec

### DIFF
--- a/packages/components/svelte-icon/package.json
+++ b/packages/components/svelte-icon/package.json
@@ -12,14 +12,14 @@
 		"lint": "prettier --plugin-search-dir . --check .",
 		"format": "prettier --plugin-search-dir . --write ."
 	},
-	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"type": "module",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
-			"default": "./dist/index.js"
+			"default": "./dist/index.js",
+			"svelte": "./dist/index.js"
 		}
 	},
 	"files": [


### PR DESCRIPTION
See [FAQ](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition).

Fixes https://github.com/steeze-ui/icons/issues/62